### PR TITLE
feat: add flag api

### DIFF
--- a/handler/user.go
+++ b/handler/user.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"fin_test/request"
 	"fin_test/service"
 	"fin_test/response"
@@ -15,5 +16,19 @@ func UserLogin(c echo.Context) error {
 
 	encriptedUserInfo := service.GetEncriptedUserInfo(body.UserName, body.Password)
 	c.JSON(200, response.UserToken(encriptedUserInfo))
+	return nil
+}
+
+func GetFlag(c echo.Context) error {
+	body, err := request.GetFlagBody(c)
+	if err != nil {
+		c.JSON(400, nil)
+	}
+
+	fmt.Println("##############################")
+	fmt.Println("flag is: %s", body.Flag)
+	fmt.Println("##############################")
+
+	c.JSON(200, nil)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -17,10 +17,11 @@ func main() {
         e.GET("/", func(c echo.Context) error {return HealthCheck(c) })
         e.PUT("/login", func(c echo.Context) error {return handler.UserLogin(c) })
 
+        e.PUT("/flag", func(c echo.Context) error {return handler.GetFlag(c) })
         e.Logger.Fatal(e.Start(":9000"))
 
 }
 func HealthCheck(c echo.Context) error {
         c.JSON(200, "health check is ok!")
-        return nil
+	return nil 
 }

--- a/request/user.go
+++ b/request/user.go
@@ -9,8 +9,20 @@ type UserLoginBody struct {
 	Password string `json:"password"`
 }
 
+type FlagBody struct {
+	Flag string `json:"flag"`
+}
+
 func GetUserLoginBody(c echo.Context) (*UserLoginBody, error)  {
 	var body UserLoginBody
+	if err := c.Bind(&body); err != nil {
+		return nil, err
+	}
+	return &body, nil
+}
+
+func GetFlagBody(c echo.Context) (*FlagBody, error) {
+	var body FlagBody
 	if err := c.Bind(&body); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### ゴール
https://finatextgroup.kibe.la/shared/entries/e0d40c00-8b1c-4bff-8b10-7d646f4b604c#%E5%95%8F%E9%A1%8C3-2-http---api%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%81%AE%E6%A7%8B%E7%AF%89%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3
 の課題を解くために`PUT /flag`を受け付けるAPIを作成する。

### 動作確認
```
curl -X PUT http://localhost:9000/flag \
     -H "Content-Type: application/json" \
     -d '{"flag": "hogehogehogoehgeogheohgeo"}'
```